### PR TITLE
Tmp kvadls to s3 sync - fix retry and SFTP limits

### DIFF
--- a/pipeline/PL_KVADLS_TO_JJS3.json
+++ b/pipeline/PL_KVADLS_TO_JJS3.json
@@ -15,8 +15,8 @@
 				],
 				"policy": {
 					"timeout": "0.12:00:00",
-					"retry": 0,
-					"retryIntervalInSeconds": 30,
+					"retry": 1,
+					"retryIntervalInSeconds": 720,
 					"secureOutput": false,
 					"secureInput": false
 				},
@@ -26,7 +26,7 @@
 						"type": "BinarySource",
 						"storeSettings": {
 							"type": "AzureBlobFSReadSettings",
-							"maxConcurrentConnections": 10,
+							"maxConcurrentConnections": 1,
 							"recursive": true,
 							"deleteFilesAfterCompletion": false
 						},
@@ -38,10 +38,10 @@
 						"type": "BinarySink",
 						"storeSettings": {
 							"type": "SftpWriteSettings",
-							"maxConcurrentConnections": 10,
+							"maxConcurrentConnections": 1,
 							"copyBehavior": "PreserveHierarchy",
 							"operationTimeout": "01:00:00",
-							"useTempFileRename": true
+							"useTempFileRename": false
 						}
 					},
 					"enableStaging": false
@@ -114,7 +114,7 @@
 				}
 			}
 		],
-		"concurrency": 10,
+		"concurrency": 1,
 		"parameters": {
 			"folderPath": {
 				"type": "string",


### PR DESCRIPTION
Tmp kvadls to s3 sync - fix retry and SFTP limits